### PR TITLE
Fix multiple bugs: axis scale callback, save/load state, path separators, dead code

### DIFF
--- a/app_exported.m
+++ b/app_exported.m
@@ -662,7 +662,11 @@ classdef app_exported < matlab.apps.AppBase
             s.axis_scale_m = app.AxisScaleDropDownM.Value;
             s.axis_scale_dMdH = app.AxisScaleDropDowndMdH.Value;
             s.axis_scale_hdMdH = app.AxisScaleDropDownHdMdH.Value;
+            s.fitting_show_grid_m_checkbox = app.ShowgridCheckBoxM.Value;
+            s.fitting_show_grid_dmdh_checkbox = app.ShowgridCheckBoxdMdH.Value;
             s.fitting_show_grid_checkbox = app.ShowgridCheckBoxHdMdH.Value;
+            s.fitting_plot_components_m_checkbox = app.PlotcomponentsCheckBoxM.Value;
+            s.fitting_plot_components_dmdh_checkbox = app.PlotcomponentsCheckBoxdMdH.Value;
             s.fitting_plot_components_checkbox = app.PlotcomponentsCheckBoxHdMdH.Value;
             
 
@@ -718,7 +722,7 @@ classdef app_exported < matlab.apps.AppBase
 
         % Code that executes after component creation
         function startupFcn(app)
-            addpath(".\src");
+            addpath(fullfile(fileparts(mfilename('fullpath')), 'src'));
             import_src();
 
             app.ProjectPath = "";
@@ -744,7 +748,7 @@ classdef app_exported < matlab.apps.AppBase
 
 
 
-            app.OutputDatasetPath.Value = strcat(pwd(), '\data');
+            app.OutputDatasetPath.Value = fullfile(pwd(), 'data');
             
             msg = sprintf("[%s] %s", app.get_time_string(), "MagAnalyst 1.0.3-beta");
             app.MessagesTextArea.Value(end) = cellstr(msg);
@@ -788,7 +792,7 @@ classdef app_exported < matlab.apps.AppBase
 
         % Button pushed function: InputBrowseButton
         function InputBrowseButtonPushed(app, event)
-            [file,path] = uigetfile('*.csv','Select dataset file', '.\data');
+            [file,path] = uigetfile('*.csv','Select dataset file', fullfile(pwd(), 'data'));
             if strcat(path, file) == ""
                 return
             end
@@ -809,9 +813,17 @@ classdef app_exported < matlab.apps.AppBase
         % Value changed function: InputDatasetPath
         function InputDatasetPathValueChanged(app, event)
             dataset_path = app.InputDatasetPath.Value;
-            [app.H, app.M] = Parser(dataset_path).get_data_csv;
-            update_components(app)
-            calculate_parameters(app)
+            if dataset_path == "" || ~isfile(dataset_path)
+                return
+            end
+            try
+                app.import_data(dataset_path);
+                update_components(app)
+                calculate_parameters(app)
+                app.plot_input();
+            catch e
+                app.write_message("Import failed: " + e.message);
+            end
         end
 
         % Callback function
@@ -880,7 +892,7 @@ classdef app_exported < matlab.apps.AppBase
                     t.Properties.VariableNames = variable_names;
                 end
                 file_name = strcat(app.EditFieldFileNameModeledAnhystereticMagnetization.Value, app.DropDownOutputModeledAnhystereticMagnetizationExtension.Value);
-                path = strcat(app.OutputDatasetPath.Value, '\', file_name);
+                path = fullfile(app.OutputDatasetPath.Value, file_name);
                 writetable(t,path, 'Delimiter', ';');
                 app.write_message("Modeled data saved as " + file_name);
             end
@@ -889,7 +901,7 @@ classdef app_exported < matlab.apps.AppBase
                 t = table(transpose(app.data_curve.H), transpose(app.data_curve.M));
                 t.Properties.VariableNames(:) = {'H [A/m]' 'M [A/m]'};
                 file_name = strcat(app.EditFieldFileNameExperimentalMagnetizationData.Value, app.DropDownOutputExperimentalMagnetizationData.Value);
-                path = strcat(app.OutputDatasetPath.Value, '\', file_name);
+                path = fullfile(app.OutputDatasetPath.Value, file_name);
                 writetable(t,path, 'Delimiter', ';');
                 app.write_message("Experimental data saved as " + file_name);
             end
@@ -953,7 +965,7 @@ classdef app_exported < matlab.apps.AppBase
                 return;
             end
             file_name = strcat(app.EditFieldFileNameParameters.Value, app.DropDownOutputParametersExtension.Value);
-            path = strcat(app.OutputDatasetPath.Value, '\', file_name);
+            path = fullfile(app.OutputDatasetPath.Value, file_name);
             file = fopen(path,'w');
             fprintf(file, "Parameters:" + newline);
             if(app.ExportFittedparametersCheckBox.Value == 1)
@@ -1023,7 +1035,7 @@ classdef app_exported < matlab.apps.AppBase
 
             if (app.CheckBoxExportPlotMagnetization.Value == 1)
                 file_name = strcat(app.EditFieldFileNamePlotMagnetization.Value, app.DropDownPlotMagnetizacionExtension.Value);
-                path = strcat(app.OutputDatasetPath.Value, '\', file_name);
+                path = fullfile(app.OutputDatasetPath.Value, file_name);
                 exportgraphics(app.AxesM,path,'Resolution',400);
                 message = strcat("Magnetization plots exported as ",file_name);
                 app.write_message(message);
@@ -1031,7 +1043,7 @@ classdef app_exported < matlab.apps.AppBase
 
             if (app.CheckBoxExportPlotSusceptibility.Value == 1)
                 file_name = strcat(app.EditFieldFileNamePlotSusceptibility.Value, app.DropDownPlotSusceptibilityExtension.Value);
-                path = strcat(app.OutputDatasetPath.Value, '\', file_name);
+                path = fullfile(app.OutputDatasetPath.Value, file_name);
                 exportgraphics(app.AxesdMdH,path,'Resolution',400);
                 message = strcat("Susceptibility plots exported as ",file_name);
                 app.write_message(message);
@@ -1039,7 +1051,7 @@ classdef app_exported < matlab.apps.AppBase
 
             if(app.CheckBoxExportPlotSemiLogMagDerivative.Value == 1)
                 file_name = strcat(app.EditFieldFileNamePlotSemiLogMagDerivative.Value, app.DropDownPlotSemiLogMagDerivativeExtension.Value);
-                path = strcat(app.OutputDatasetPath.Value, '\', file_name);
+                path = fullfile(app.OutputDatasetPath.Value, file_name);
                 exportgraphics(app.AxesHdMdH,path,'Resolution',400);
                 message = strcat("Semi-Log Magnetization Derivative plots exported as ",file_name);
                 app.write_message(message);
@@ -1048,7 +1060,7 @@ classdef app_exported < matlab.apps.AppBase
 
         % Menu selected function: SaveasMenu
         function SaveasMenuSelected(app, event)
-          [file,path] = uiputfile('*.txt','Save project', '.\data\project.txt');
+          [file,path] = uiputfile('*.txt','Save project', fullfile(pwd(), 'data', 'project.txt'));
           app.ProjectPath = strcat(path, file);
           app.save();
         end
@@ -1057,7 +1069,7 @@ classdef app_exported < matlab.apps.AppBase
         function OpenMenuSelected(app, event)
             app.write_message("Opening new project");
             pause(0.01);
-            [file,path] = uigetfile('*.txt','Select project', '.\data');
+            [file,path] = uigetfile('*.txt','Select project', fullfile(pwd(), 'data'));
             app.ProjectPath = strcat(path, file);
 
             data = fileread(app.ProjectPath);
@@ -1097,7 +1109,31 @@ classdef app_exported < matlab.apps.AppBase
             app.EditFieldFileNameResiduesSusceptibility.Value = s.susceptibility_residual_file_name;
             app.EditFieldFileNameResiduesSemiLogMagDerivative.Value = s.semi_log_derivative_file_name;
 
+            if isfield(s, 'input_axis_scale')
+                app.InputAxisScaleDropDown.Value = s.input_axis_scale;
+            end
+            if isfield(s, 'axis_scale_m')
+                app.AxisScaleDropDownM.Value = s.axis_scale_m;
+            end
+            if isfield(s, 'axis_scale_dMdH')
+                app.AxisScaleDropDowndMdH.Value = s.axis_scale_dMdH;
+            end
+            if isfield(s, 'axis_scale_hdMdH')
+                app.AxisScaleDropDownHdMdH.Value = s.axis_scale_hdMdH;
+            end
+            if isfield(s, 'fitting_show_grid_m_checkbox')
+                app.ShowgridCheckBoxM.Value = s.fitting_show_grid_m_checkbox;
+            end
+            if isfield(s, 'fitting_show_grid_dmdh_checkbox')
+                app.ShowgridCheckBoxdMdH.Value = s.fitting_show_grid_dmdh_checkbox;
+            end
             app.ShowgridCheckBoxHdMdH.Value = s.fitting_show_grid_checkbox;
+            if isfield(s, 'fitting_plot_components_m_checkbox')
+                app.PlotcomponentsCheckBoxM.Value = s.fitting_plot_components_m_checkbox;
+            end
+            if isfield(s, 'fitting_plot_components_dmdh_checkbox')
+                app.PlotcomponentsCheckBoxdMdH.Value = s.fitting_plot_components_dmdh_checkbox;
+            end
             app.PlotcomponentsCheckBoxHdMdH.Value = s.fitting_plot_components_checkbox;
             app.CheckBoxOutputMagnetizationDataFittedAnhystereticMagnetization.Value = s.model_magnetization_checkbox;
             app.OutputSeparateComponentsCheckBox.Value = s.model_magnetization_components_checkbox;
@@ -1174,32 +1210,22 @@ classdef app_exported < matlab.apps.AppBase
             app.apply_axis_scale(app.AxesRawInputData, value);
         end
 
-        % Callback function
-        function InputAxisScaleDropDownValueChanged(app, event)
-            app.InputAxisScaleDropDown.Value;
-            app.plot_HdMdH();
-            axis_scale = string(app.AxisScaleDropDownHdMdH.Value);
-            app.apply_axis_scale(app.AxesHdMdH, axis_scale);
-        end
-
         % Value changed function: AxisScaleDropDownM
         function AxisScaleDropDownMValueChanged(app, event)
-            app.AxisScaleDropDownM.Value;
             axis_scale = string(app.AxisScaleDropDownM.Value);
             app.apply_axis_scale(app.AxesM, axis_scale);
         end
 
         % Value changed function: AxisScaleDropDowndMdH
         function AxisScaleDropDowndMdHValueChanged(app, event)
-            app.AxisScaleDropDowndMdH.Value;
             axis_scale = string(app.AxisScaleDropDowndMdH.Value);
             app.apply_axis_scale(app.AxesdMdH, axis_scale); 
         end
 
         % Value changed function: AxisScaleDropDownHdMdH
         function AxisScaleDropDownHdMdHValueChanged(app, event)
-            app.AxisScaleDropDownHdMdH.Value;
-            
+            axis_scale = string(app.AxisScaleDropDownHdMdH.Value);
+            app.apply_axis_scale(app.AxesHdMdH, axis_scale);
         end
 
         % Value changed function: CurveDropDown

--- a/src/ErrorCalculator/DiagonalErrorCalculator.m
+++ b/src/ErrorCalculator/DiagonalErrorCalculator.m
@@ -6,12 +6,8 @@ classdef DiagonalErrorCalculator < ErrorCalculator
         end
 
         function e = get_error(obj)
-            obj.X = obj.X(1:end);
-            obj.Y = obj.Y(1:end);
-%             Ydat = obj.Y(1:end-1);    % it was not necessary to remove last element; it is better to add the if && structure. Clean code!!
-%             Xdat = obj.X(1:end-1);
-            Ydat = obj.Y(1:end);
-            Xdat = obj.X(1:end);
+            Ydat = obj.Y;
+            Xdat = obj.X;
 
             e = 0;
             for i = 1:length(Ydat)


### PR DESCRIPTION
- AxisScaleDropDownHdMdHValueChanged now applies the axis scale (was a no-op)
- save() now persists axis scale and show-grid/plot-components checkboxes for
  all three plots (M, dMdH, HdMdH); load() restores them with isfield guards
  for backward compatibility with older project files
- InputDatasetPathValueChanged fixed to use import_data() instead of
  referencing nonexistent app.H/app.M properties via an obsolete Parser API
- Replaced all hardcoded Windows backslash path separators with fullfile() so
  the toolbox runs correctly on Linux and macOS
- Removed dead InputAxisScaleDropDownValueChanged callback (never wired up;
  actual callback is InputAxisScaleDropDownValueChanged2)
- Removed no-op value reads (app.AxisScaleDropDownM.Value; etc.) in axis
  scale callbacks
- DiagonalErrorCalculator: removed no-op self-assignments and stale comments

https://claude.ai/code/session_01Pya1z3JR3i16gCv7JDinxg